### PR TITLE
[WIP] Adding a basic benchmark that checks the time taken vs. point cloud size

### DIFF
--- a/src/standalone/tests/CMakeLists.txt
+++ b/src/standalone/tests/CMakeLists.txt
@@ -1,10 +1,35 @@
+# Test utils
+add_library(lvox_test_utils)
+
+target_sources(lvox_test_utils
+  PRIVATE
+  utils/utils.cpp
+)
+
+target_include_directories(lvox_test_utils
+    PUBLIC
+    ${neolvox_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_target_properties(lvox_test_utils
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+target_link_libraries(lvox_test_utils PUBLIC
+    pdalcpp
+    Eigen3::Eigen
+    lvox_common
+)
+
+# Tests
 find_package(GTest 1.14.0 REQUIRED)
 
 add_executable(lvox_tests)
 
 target_sources(lvox_tests
     PRIVATE
-    utils/utils.cpp
     scanner/test_spherical_scanner.cpp
     voxel/test_grid_at.cpp
     voxel/test_grid_cell_count.cpp
@@ -19,14 +44,13 @@ target_sources(lvox_tests
 
 target_include_directories(lvox_tests
     PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR})
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 target_link_libraries(lvox_tests
     GTest::GTest
     GTest::gtest_main
-    pdalcpp
-    Eigen3::Eigen
-    lvox_common
+    lvox_test_utils
 )
 
 if (WIN32)
@@ -42,3 +66,32 @@ set_target_properties(lvox_tests
 
 include(GoogleTest)
 gtest_discover_tests(lvox_tests)
+
+# Benchmarks
+find_package(benchmark REQUIRED)
+
+add_executable(lvox_benchs)
+
+target_sources(lvox_benchs
+    PRIVATE
+    benchmarks/bench_point_cloud_size.cpp
+    benchmarks/main.cpp
+)
+
+target_include_directories(lvox_benchs
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${lvox_tests_SOURCE_DIR}
+)
+
+target_link_libraries(lvox_benchs
+    benchmark::benchmark
+    lvox_test_utils
+)
+
+target_include_directories(lvox_benchs PUBLIC ${neolvox_SOURCE_DIR}/include)
+
+set_target_properties(lvox_benchs
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/src/standalone/tests/benchmarks/bench_point_cloud_size.cpp
+++ b/src/standalone/tests/benchmarks/bench_point_cloud_size.cpp
@@ -1,0 +1,60 @@
+#include <benchmark/benchmark.h>
+#include <memory>
+#include <thread>
+#include <utils/utils.hpp>
+#include <pdal/Dimension.hpp>
+#include <pdal/PointView.hpp>
+
+#include <lvox/voxel/grid.hpp>
+#include <lvox/algorithms/algorithms.hpp>
+#include <lvox/scanner/scan.hpp>
+#include <lvox/types.hpp>
+#include <lvox/algorithms/pad_estimators.hpp>
+#include "lvox/logger/logger.hpp"
+
+static auto bm_point_cloud_size(benchmark::State& state) -> void
+{
+    for (auto _ : state)
+    {
+        state.PauseTiming();
+        pdal::PointTable table;
+        lvox::Logger     logger{"Benchmark"};
+        logger.info("Generating point cloud");
+        const auto       view = generate_cubic_point_cloud_with_random_points(table, state.range(0));
+
+        lvox::Bounds point_cloud_bounds;
+        const double         cell_size = 0.5;
+        view->calculateBounds(point_cloud_bounds);
+
+        using dim = pdal::Dimension::Id;
+
+        logger.info("Converting to LVox format");
+        auto lvox_point_cloud = std::make_unique<lvox::PointCloud>();
+        for (const auto& pt : *view)
+        {
+            const double x        = pt.template getFieldAs<double>(dim::X);
+            const double y        = pt.template getFieldAs<double>(dim::Y);
+            const double z        = pt.template getFieldAs<double>(dim::Z);
+            const double gps_time = pt.template getFieldAs<double>(dim::GpsTime);
+            lvox_point_cloud->emplace_back(gps_time, lvox::Point{x, y, z});
+        }
+
+        std::vector<lvox::Scan> scans;
+        scans.emplace_back(
+            std::move(lvox_point_cloud), lvox::Point{0., 0., 0.}, point_cloud_bounds
+        );
+        lvox::algorithms::ComputeOptions options{
+            .m_voxel_size           = 0.3,
+            .m_job_limit            = std::thread::hardware_concurrency(),
+            .m_pad_estimator        = lvox::algorithms::pad_estimators::BeerLambert{},
+            .m_compute_theoriticals = false
+        };
+        logger.info("Starting computation");
+        lvox::Logger::set_global_level(lvox::Logger::Level::Error);
+
+        state.ResumeTiming();
+        lvox::algorithms::compute_pad(scans, options);
+    }
+}
+
+BENCHMARK(bm_point_cloud_size)->Arg(10'000)->Arg(100'000)->Arg(1'000'000)->Arg(10'000'000)->Complexity(benchmark::oN);

--- a/src/standalone/tests/benchmarks/main.cpp
+++ b/src/standalone/tests/benchmarks/main.cpp
@@ -1,0 +1,3 @@
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/src/standalone/tests/utils/utils.cpp
+++ b/src/standalone/tests/utils/utils.cpp
@@ -1,9 +1,28 @@
+#include <chrono>
+#include <random>
+#include <ranges>
 #include <utils/utils.hpp>
 
 #include <pdal/PointTable.hpp>
 #include <pdal/PointView.hpp>
 
 #include <lvox/types.hpp>
+
+auto get_current_time_as_gps_time() -> double
+{
+    namespace c = std::chrono;
+    const auto current_time = c::system_clock::now().time_since_epoch();
+    return static_cast<double>(c::duration_cast<c::microseconds>(current_time).count());
+}
+
+Point::Point(double x, double y, double z, double gps_time)
+    : x{x}
+    , y{y}
+    , z{z}
+    , gps_time{gps_time}
+{
+}
+
 
 auto create_bounds(double dim_x, double dim_y, double dim_z) -> pdal::BOX3D
 {
@@ -21,16 +40,10 @@ auto create_bounds(double dim_x, double dim_y, double dim_z) -> pdal::BOX3D
 auto generate_cubic_point_cloud(pdal::PointTableRef table, double dim_x, double dim_y, double dim_z)
     -> pdal::PointViewPtr
 {
-    struct Point
-    {
-        double x;
-        double y;
-        double z;
-    };
-
     table.layout()->registerDim(pdal::Dimension::Id::X);
     table.layout()->registerDim(pdal::Dimension::Id::Y);
     table.layout()->registerDim(pdal::Dimension::Id::Z);
+    table.layout()->registerDim(pdal::Dimension::Id::GpsTime);
 
     pdal::PointViewPtr view{std::make_unique<pdal::PointView>(table)};
     const double       half_dim_x = dim_x / 2.0;
@@ -50,11 +63,40 @@ auto generate_cubic_point_cloud(pdal::PointTableRef table, double dim_x, double 
         Point{half_dim_x, -half_dim_y, -half_dim_z},
     };
 
-    for (lvox::Index i = 0; i < cube.size(); ++i)
+    for (const auto [i, point] : cube | std::views::enumerate)
     {
         view->setField(pdal::Dimension::Id::X, i, cube[i].x);
         view->setField(pdal::Dimension::Id::Y, i, cube[i].y);
         view->setField(pdal::Dimension::Id::Z, i, cube[i].z);
+    }
+
+    return view;
+}
+
+auto generate_cubic_point_cloud_with_random_points(pdal::PointTableRef table, size_t point_count, double dim_x, double dim_y, double dim_z)
+    -> pdal::PointViewPtr
+{
+    table.layout()->registerDim(pdal::Dimension::Id::X);
+    table.layout()->registerDim(pdal::Dimension::Id::Y);
+    table.layout()->registerDim(pdal::Dimension::Id::Z);
+    table.layout()->registerDim(pdal::Dimension::Id::GpsTime);
+
+    pdal::PointViewPtr view{std::make_unique<pdal::PointView>(table)};
+    const double       half_dim_x = dim_x / 2.0;
+    const double       half_dim_y = dim_y / 2.0;
+    const double       half_dim_z = dim_z / 2.0;
+
+    // Fixing the seed for reproducibility. Maybe not that useful?
+    std::mt19937 gen{1337};
+    std::uniform_real_distribution<double> dis_x(-half_dim_x, half_dim_x);
+    std::uniform_real_distribution<double> dis_y(-half_dim_y, half_dim_y);
+    std::uniform_real_distribution<double> dis_z(-half_dim_z, half_dim_z);
+
+    for (lvox::Index i = 0; i < point_count; ++i)
+    {
+        view->setField(pdal::Dimension::Id::X, i, dis_x(gen));
+        view->setField(pdal::Dimension::Id::Y, i, dis_y(gen));
+        view->setField(pdal::Dimension::Id::Z, i, dis_z(gen));
     }
 
     return view;

--- a/src/standalone/tests/utils/utils.hpp
+++ b/src/standalone/tests/utils/utils.hpp
@@ -5,6 +5,18 @@
 #include <pdal/PointTable.hpp>
 #include <pdal/util/Bounds.hpp>
 
+auto get_current_time_as_gps_time() -> double;
+
+struct Point
+{
+    Point(double x, double y, double z, double gps_time = get_current_time_as_gps_time());
+
+    double x;
+    double y;
+    double z;
+    double gps_time;
+};
+
 // Creates a bound from -(dim/2) to (dim/2)
 auto create_bounds(double dim_x, double dim_y, double dim_z) -> pdal::BOX3D;
 
@@ -12,5 +24,11 @@ auto create_bounds(double dim_x, double dim_y, double dim_z) -> pdal::BOX3D;
 auto generate_cubic_point_cloud(
     pdal::PointTableRef table, double dim_x = 2., double dim_y = 2., double dim_z = 2.
 ) -> pdal::PointViewPtr;
+
+// Generates a point cloud of N points all located within the given cubic bounds.
+auto generate_cubic_point_cloud_with_random_points(
+    pdal::PointTableRef table, size_t point_count, double dim_x = 2., double dim_y = 2., double dim_z = 2.
+) -> pdal::PointViewPtr;
+
 
 #endif // !LVOX_TEST_GRID_HELPERS


### PR DESCRIPTION
Hello @tdhock !

Here's a quick draft of the benchmark utility written in C++ using Google's benchmark library.

So far, I've tested only what happens when increasing the point cloud size in terms of the time it takes to compute it.

Here's a crude graph I've made in Excel really quick:

<img width="605" height="341" alt="quick_result" src="https://github.com/user-attachments/assets/51aeed8c-d6d8-4077-b8de-0e0d97907a00" />

If I'm not mistaken, I think our assumption is true: the algorithm seems to be O(n).

The graph making process will be improved soon!

I'm thinking that the next step would be to check with same data count but by changing the threading amount! 